### PR TITLE
Add newer unmanned parts to RT Patch

### DIFF
--- a/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_RT.cfg
+++ b/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_RT.cfg
@@ -31,3 +31,54 @@
 		}
 	}
 }
+
+@PART[WBI_ControlModule]:FOR[MOLE]:NEEDS[RemoteTech]
+{
+	MODULE[ModuleSPU] {
+	}
+	
+	MODULE[ModuleRTAntennaPassive]	{
+		TechRequired = unmannedTech
+		OmniRange = 3000
+		
+		TRANSMITTER {
+			PacketInterval = 0.3
+			PacketSize = 2
+			PacketResourceCost = 15.0
+		}
+	}
+}
+
+@PART[WBI_Korona,WBI_KoronaLite]:FOR[MOLE]:NEEDS[RemoteTech]
+{
+	MODULE[ModuleSPU] {
+	}
+	
+	MODULE[ModuleRTAntennaPassive]	{
+		TechRequired = unmannedTech
+		OmniRange = 3000
+		
+		TRANSMITTER {
+			PacketInterval = 0.3
+			PacketSize = 2
+			PacketResourceCost = 15.0
+		}
+	}
+}
+
+@PART[WBI_StationHub2]:FOR[MOLE]:NEEDS[RemoteTech]
+{
+	MODULE[ModuleSPU] {
+	}
+	
+	MODULE[ModuleRTAntennaPassive]	{
+		TechRequired = unmannedTech
+		OmniRange = 3000
+		
+		TRANSMITTER {
+			PacketInterval = 0.3
+			PacketSize = 2
+			PacketResourceCost = 15.0
+		}
+	}
+}

--- a/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_RT.cfg
+++ b/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_RT.cfg
@@ -1,84 +1,89 @@
 @PART[WBI_TitanInstrumentUnit]:FOR[MOLE]:NEEDS[RemoteTech]
 {
-	MODULE[ModuleSPU] {
-	}
+	!MODULE[ModuleDataTransmitter] {}
 	
-	MODULE[ModuleRTAntennaPassive]	{
-		TechRequired = unmannedTech
-		OmniRange = 3000
+	%MODULE[ModuleSPU] {}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
 		
-		TRANSMITTER {
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 }
 
 @PART[WBI_Backseat2]:FOR[MOLE]:NEEDS[RemoteTech]
 {
-	MODULE[ModuleSPU] {
-	}
+	!MODULE[ModuleDataTransmitter] {}
 	
-	MODULE[ModuleRTAntennaPassive]	{
-		TechRequired = unmannedTech
-		OmniRange = 3000
+	%MODULE[ModuleSPU] {}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
 		
-		TRANSMITTER {
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 }
 
 @PART[WBI_ControlModule]:FOR[MOLE]:NEEDS[RemoteTech]
 {
-	MODULE[ModuleSPU] {
-	}
+	!MODULE[ModuleDataTransmitter] {}
 	
-	MODULE[ModuleRTAntennaPassive]	{
-		TechRequired = unmannedTech
-		OmniRange = 3000
+	%MODULE[ModuleSPU] {}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
 		
-		TRANSMITTER {
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 }
 
 @PART[WBI_Korona,WBI_KoronaLite]:FOR[MOLE]:NEEDS[RemoteTech]
 {
-	MODULE[ModuleSPU] {
-	}
+	!MODULE[ModuleDataTransmitter] {}
 	
-	MODULE[ModuleRTAntennaPassive]	{
-		TechRequired = unmannedTech
-		OmniRange = 3000
+	%MODULE[ModuleSPU] {}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
 		
-		TRANSMITTER {
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 }
 
 @PART[WBI_StationHub2]:FOR[MOLE]:NEEDS[RemoteTech]
 {
-	MODULE[ModuleSPU] {
-	}
+	!MODULE[ModuleDataTransmitter] {}
 	
-	MODULE[ModuleRTAntennaPassive]	{
-		TechRequired = unmannedTech
-		OmniRange = 3000
+	%MODULE[ModuleSPU] {}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
 		
-		TRANSMITTER {
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 }


### PR DESCRIPTION
This adds the basic module/standard onboard antenna for the new radial probe core, the two Koronas and the StationHub, to match the Backseat and Titan Instrument modules.
