### PR TITLE
More Science Defs

### DIFF
--- a/GameData/WildBlueIndustries/000WildBlueTools/Resources/BasicExperiments.cfg
+++ b/GameData/WildBlueIndustries/000WildBlueTools/Resources/BasicExperiments.cfg
@@ -1,16 +1,16 @@
 //Experiment used by MOLE's bonus science research.
 //NOT part of the WBIModuleScienceExperiment system.
 EXPERIMENT_DEFINITION
-{	
+{
 	id = WBISpaceResearch
 	title = Space Research
 	baseValue = 10
 	scienceCap = 50
-	dataScale = 2	
+	dataScale = 2
 	requireAtmosphere = False
 	situationMask = 3
 	biomeMask = 3
-	
+
 	RESULTS
 	{
 		default = Research shows that living and working in space is possible.
@@ -73,7 +73,7 @@ EXPERIMENT_DEFINITION
 //	chanceOfSuccess = 65
 
 	//Cost of the experiment (does not include resource costs)
-//	cost = 
+//	cost =
 
 	//Parts required to run the experiment
 	//You can have several requiredPart entries
@@ -87,7 +87,7 @@ EXPERIMENT_DEFINITION
 //	minAltitude =
 
 	//Maximum altitude required to run the experiment, in meters
-//	maxAltitude = 
+//	maxAltitude =
 
 	//Format: ResourceName,Amount;ResourceName,Amount
 	requiredResources = LabTime,36
@@ -227,7 +227,7 @@ EXPERIMENT_DEFINITION
 	minCrew = 1
 	tags = basic
 	requiredResources = LabTime,36
-	situations = ORBITING
+	situations = ORBITING;LANDED
 
 	RESULTS
 	{
@@ -247,6 +247,10 @@ EXPERIMENT_DEFINITION
 		VallInSpace = You come up with the idea of adding blueberries and blue tint to the ice cream.
 		DresInSpace = This batch of ice cream has chunks of ice in it. It's a complete disaster. Hm...
 		EelooInSpace = After looking at the window, you decide to add cookies and cream into the mixture.
+		MinmusSrfLanded = The surface of Minmus is *not* repeat *not* made of ice cream.  On an unrelated note, does Jeb have that shipment of packaging equipment ready to send up yet?
+		MinmusSrfLanded = Rumors that we are shipping Minmus home as ice cream are completely untrue.  It'd be to expensive.
+		MunSrfLanded = Munar regolith appears to be a decent insulation material for ice cream containers, once stabilized.
+		DunSrfLanded = Sitting out on the rolling red plains, eating ice cream...  It gives you time to think and reflect on the big questions in life, like 'Why am I here?', or 'What is my purpose in life?', or 'Do we have any food that isn't ice cream?', or 'Shouldn't I be wearing a helmet?'
 	}
 }
 
@@ -264,6 +268,8 @@ EXPERIMENT_DEFINITION
     	description = The DStaal Institute of Technology (DIT) came up with this study to learn how temperatures change in space. Does being in the sun help? We're not sure yet - go find out.
 	requiredResources = LabTime,18
 	requiredPart = 2HOT Thermometer
+	requiredPart = Univ. Storage - PresMat / 2Hot
+	requiredPart = CA-SC100 Thermometer
 	situations = ORBITING;LANDED
 
 	RESULTS
@@ -279,6 +285,9 @@ EXPERIMENT_DEFINITION
 		KerbinInSpace = Temperature readings appear to be largely dependent on whether the thermometer is exposed to Kerbol at the time of the reading.
 		KerbinInSpace = Experimental readings were disrupted by Bill trying to bake a cake.  Where he found an oven we're not sure.  The cake was delicious though.
 		KerbinInSpace = Temperatures inside the ship are largely as set by the life support system.  Wait, you wanted us to measure the *outside* temperature changes?
+
+		MunSrfLanded = Temperature changes appear to be extreme on the Munar surface - dependent largely on the position of the sun.
+		MinmusSrfLanded = Temperatures here are a bit warm - for ice cream.
 	}
 }
 
@@ -296,6 +305,8 @@ EXPERIMENT_DEFINITION
     	description = Living in space requires keeping things hot or cold - study how different materials transmit heat in space. Sponsored by the DStaal Institute of Technology (DIT).
 	requiredResources = LabTime,18
 	requiredPart = 2HOT Thermometer
+	requiredPart = Univ. Storage - PresMat / 2Hot
+	requiredPart = CA-SC100 Thermometer
 	situations = ORBITING;LANDED
 
 	RESULTS
@@ -308,6 +319,43 @@ EXPERIMENT_DEFINITION
 		KerbinInSpace = Without air outside, it's harder than expected to keep the ship cool.  I thought space was cold?
 		KerbinInSpace = With all heaters shut down, the ship was able to cool slowly until Jeb decided he was cold and turned them back on.
 		KerbinInSpace = Equilibrium temperature of the test module was colder than Kerbals would like to be.
+
+		MunSrfLanded = Piling Munar regolith around the ship appears to help it keep a steady temperature.
+		MunSrfLanded = You know, sitting on the surface of the Mun in vacuum isn't really that different than sitting in orbit in vacuum...  Huh.  That's weird.  Take a look at these readings.
+	}
+}
+
+EXPERIMENT_DEFINITION
+{
+	id = WBIGooStudy
+	title = Goo Study
+	baseValue = 12
+	scienceCap = 36
+	dataScale = 1
+	situationMask = 63
+	biomeMask = 3
+	tags = basic
+	mass = 0.01
+    	description = So...  We found this weird stuff in a dumpster, and we want to know more about it. Maybe sending it to space will help. Sponsored by the DStaal Institute of Technology (DIT).
+	requiredResources = LabTime,18
+	requiredPart = Mystery Goo™ Containment Unit
+	requiredPart = Univ. Storage - Mystery Goo Containment
+	requiredPart = Micro Goo Containment Pod
+	situations = ORBITING;LANDED
+
+	RESULTS
+	{
+		default = Ok, so it wobbles and jiggles in the container.  What's next?
+
+		KerbinSrfLanded = The Goo remains goo.
+		KerbinSrfSplashed = The Goo becomes watery goo.  Or is that ooze?
+
+		KerbinInSpace = Microgravity appears to cause some weird crystallization - the goo originally was one lump, but has broken up into thousands of tiny shards.  They appear to be damaging the interior of the container...
+		KerbinInSpace = The goo appears to be liquid enough for surface tension to form it into a stable sphere.  Well, unless it gets bumped.  Then it wiggles a bit until it's a sphere again.  Um, what was that about learning about the formation of the Mun?
+		KerbinInSpace = Ok, I'm bored.  The goo's a sphere, just like all the other times I checked it...  Where'd it go?
+		MunInSpace = The Goo seems to like it here.
+		MunSrfLanded = The goo has slowly expanded to fill the entire containment unit.  Pressure on the walls of the containment unit appears to be holding.
+		MunSrfLanded = You know, if we could harden it like this it'd be a good light areogel.  Just saying.
 	}
 }
 


### PR DESCRIPTION
- Added support for DMagic Orbital Science, Universal Storage, and Coatl Aerospace to thermometer experiments.
- Added some new (surface) results for the Ice Cream Experiment.
- Added some new results for thermometer experiments.
- Added new Goo experiment, with support for DMagic Orbital Science and Universal Storage.  (Coatl Areospace doesn't have a goo container.)

Signed-off-by: Daniel T. Staal DStaal@usa.net
