### PR TITLE
Updates for Kerbalism Compatibility

### DIFF
--- a/GameData/WildBlueIndustries/000WildBlueTools/ModuleManagerPatches/MM_Kerbalism.cfg
+++ b/GameData/WildBlueIndustries/000WildBlueTools/ModuleManagerPatches/MM_Kerbalism.cfg
@@ -18,6 +18,34 @@ STORAGE_TEMPLATE:NEEDS[Kerbalism]
 
 STORAGE_TEMPLATE:NEEDS[Kerbalism]
 {
+	name = Food and Water
+	author = Angel-125
+	shortName = FoodWater
+	logoPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LifeSupport
+	glowPanel = WildBlueIndustries/000WildBlueTools/CommonTemplates/Decals/LifeSupportGlow
+	description = This kit stores Food and Water in a balanced ratio.
+
+//	5600 Food and Water in a ratio of
+//	0.7224224 food
+//	0.2775776 water
+//	Further balancing needed
+	
+	RESOURCE
+	{
+		name = Food
+		amount = 4045.56544
+		maxAmount = 4045.56544
+	}
+	RESOURCE
+	{
+		name = Water
+		amount = 1554.43456
+		maxAmount = 1554.43456
+	}
+}
+
+STORAGE_TEMPLATE:NEEDS[Kerbalism]
+{
 	name = Oxygen
 	author = Angel-125
 	shortName = Oxygen

--- a/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_Kerbalism.cfg
+++ b/GameData/WildBlueIndustries/MOLE/ModuleManagerPatches/MM_Kerbalism.cfg
@@ -14,170 +14,183 @@
 		type = radiation
 	}
 
-	@MODULE[Scrubber]
-	{
-		@ec_rate = 0.06
-		@co2_rate = 0.27777774
-	}
+// Module has been replaced by new configurable modules, which are Pressure Control, CO2 Scrubber, Water Recycler, and Waste Processor
+// These are added automatically by the default Kerbalism profile to all crewed parts with 2 slots default, but it can be configured with more or fewer slots and even a restricted set of options.
 
-	RESOURCE
-	{
-		name = Food
-		amount = 100
-		maxAmount = 100
-	}
+//	@MODULE[Scrubber]
+//	{
+//		@ec_rate = 0.06
+//		@co2_rate = 0.27777774
+//	}
 
-	RESOURCE
-	{
-		name = Oxygen
-		amount = 5000
-		maxAmount = 5000
-	}
+//resources should be added automatically by Kerbalism, but balancing can be done of course, water is now part of the default profile life support
 
-	RESOURCE
-	{
-		name = Shielding
-		amount = 0
-		maxAmount = 1
-	}
+//	RESOURCE
+//	{
+//		name = Food
+//		amount = 100
+//		maxAmount = 100
+//	}
+
+//	RESOURCE
+//	{
+//		name = Water
+//		amount = 50
+//		maxAmount = 50
+//	}
+
+//	RESOURCE
+//	{
+//		name = Oxygen
+//		amount = 5000
+//		maxAmount = 5000
+//	}
+
+// Shielding has been changed to be based on surface area of the 'habitat' (part) and is added automatically by default profile to crewed parts
+//	RESOURCE
+//	{
+//		name = Shielding
+//		amount = 0
+//		maxAmount = 1
+//	}
 }
 
 @PART[WBI_BOW]:NEEDS[Kerbalism]
 {
-	@tags ^= :$: entertainment:
+	@tags ^= :$: comfort:
 
-
+//The Entertainment Module has been replaced by a Comfort Module with discrete bonuses rather than bonus rates
 	MODULE
   
 	{
     
-		name = Entertainment
+		name = Comfort
+    bonus = exercise
     
 		description = Lab experiments
  keep kerbals busy.
-		rate = 3.6
 
 	}
   
   
+//As above regarding resources and shielding
+//	RESOURCE
+//	{
+//		name = Food
+//		amount = 200
+//		maxAmount = 200
+//	}
 
-	RESOURCE
-	{
-		name = Food
-		amount = 200
-		maxAmount = 200
-	}
+//	RESOURCE
+//	{
+//		name = Oxygen
+//		amount = 10000
+//		maxAmount = 10000
+//	}
 
-	RESOURCE
-	{
-		name = Oxygen
-		amount = 10000
-		maxAmount = 10000
-	}
-
-	RESOURCE
-	{
-		name = Shielding
-		amount = 0
-		maxAmount = 2
-	}
+//	RESOURCE
+//	{
+//		name = Shielding
+//		amount = 0
+//		maxAmount = 2
+//	}
 }
 
 @PART[WBI_Mole182]:NEEDS[Kerbalism]
 {
-	@tags ^= :$: entertainment:
+	@tags ^= :$: comfort:
 
 
 	MODULE
   
 	{
     
-		name = Entertainment
+		name = Comfort
+    bonus = exercise
     
 		description = Lab experiments
  keep kerbals busy.
-		rate = 3.6
 
 	}
   
   
 
-	RESOURCE
-	{
-		name = Food
-		amount = 200
-		maxAmount = 200
-	}
+//	RESOURCE
+//	{
+//		name = Food
+//		amount = 200
+//		maxAmount = 200
+//	}
 
-	RESOURCE
-	{
-		name = Oxygen
-		amount = 10000
-		maxAmount = 10000
-	}
+//	RESOURCE
+//	{
+//		name = Oxygen
+//		amount = 10000
+//		maxAmount = 10000
+//	}
 
-	RESOURCE
-	{
-		name = Shielding
-		amount = 0
-		maxAmount = 2
-	}
+//	RESOURCE
+//	{
+//		name = Shielding
+//		amount = 0
+//		maxAmount = 2
+//	}
 }
 
 @PART[WBI_MOH18]:NEEDS[Kerbalism]
 {
-	@tags ^= :$: entertainment:
+	@tags ^= :$: comfort:
 
 
 	MODULE
   
 	{
     
-		name = Entertainment
+		name = Comfort
+		bonus = panorama
     
 		description = The windows are offer great views. My Squad, it's full of stars!
-		rate = 3.6
 
 	}
   
   
 
-	@MODULE[Scrubber]
-	{
-		@ec_rate = 0.06
-		@co2_rate = 0.41666661
-	}
+//	@MODULE[Scrubber]
+//	{
+//		@ec_rate = 0.06
+//		@co2_rate = 0.41666661
+//	}
 
-	RESOURCE
-	{
-		name = Food
-		amount = 200
-		maxAmount = 200
-	}
+//	RESOURCE
+//	{
+//		name = Food
+//		amount = 200
+//		maxAmount = 200
+//	}
 
-	RESOURCE
-	{
-		name = Oxygen
-		amount = 10000
-		maxAmount = 10000
-	}
+//	RESOURCE
+//	{
+//		name = Oxygen
+//		amount = 10000
+//		maxAmount = 10000
+//	}
 
-	RESOURCE
-	{
-		name = Shielding
-		amount = 0
-		maxAmount = 2
-	}
+//	RESOURCE
+//	{
+//		name = Shielding
+//		amount = 0
+//		maxAmount = 2
+//	}
 }
 
 @PART[WBI_AirlockModule]:NEEDS[Kerbalism]
 {
-	RESOURCE
-	{
-		name = Shielding
-		amount = 0
-		maxAmount = 1
-	}
+//	RESOURCE
+//	{
+//		name = Shielding
+//		amount = 0
+//		maxAmount = 1
+//	}
 }
 
 MOBL:NEEDS[Kerbalism]
@@ -225,9 +238,10 @@ MOBL:NEEDS[Kerbalism]
 			Ratio = 0.0002
 		}
 
+// Kerbalism makes use of Ammonia for fertilizing greenhouses and ammonia is processed from waste in the waste processor module
 		INPUT_RESOURCE
 		{
-			ResourceName = Fertilizer
+			ResourceName = Ammonia
 			Ratio = 0.00002
 		}
 
@@ -246,7 +260,7 @@ MOBL:NEEDS[Kerbalism]
 
 	RESOURCE
 	{
-		name = Fertilizer
+		name = Ammonia
 		amount = 250
 		maxAmount = 250
 		isTweakable = true

--- a/GameData/WildBlueIndustries/MOLE/Parts/Command/Backseat.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Command/Backseat.cfg
@@ -504,8 +504,15 @@ BACKSEAT
 	RESOURCE:NEEDS[Kerbalism]
 	{
 		name = Food
-		amount = 1333.333333333333
-		maxAmount = 1333.333333333333
+		amount = 963.2298666667
+		maxAmount = 963.2298666667
+	}
+	// added water and coverted 1333.333333333333 to ratio of 0.7224224 food and 0.2775776 water
+	RESOURCE:NEEDS[Kerbalism]
+	{
+		name = Water
+		amount = 370.1034666667
+		maxAmount = 370.1034666667
 	}
 
 	RESOURCE:NEEDS[Kerbalism]

--- a/GameData/WildBlueIndustries/MOLE/Parts/Science/MOBL18.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Science/MOBL18.cfg
@@ -114,8 +114,8 @@ PART
 		//Snacks
 		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
 
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+		//Kerbalism, now with more possible resources, partly based on which configuration of Life Support Modules are in place
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen;Water;Nitrogen;Waste;WasteWater;Ammonia
 
 		//TAC-LS
 		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater

--- a/GameData/WildBlueIndustries/MOLE/Parts/Science/Mole18.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Science/Mole18.cfg
@@ -142,8 +142,8 @@ PART
 		//Snacks
 		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
 
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+		//Kerbalism, now with more possible resources, partly based on which configuration of Life Support Modules are in place
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen;Water;Nitrogen;Waste;WasteWater;Ammonia
 
 		//TAC-LS
 		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater

--- a/GameData/WildBlueIndustries/MOLE/Parts/Utility/BOW.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Utility/BOW.cfg
@@ -288,8 +288,8 @@ PART
 		//Snacks
 		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
 
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+		//Kerbalism, now with more possible resources, partly based on which configuration of Life Support Modules are in place
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen;Water;Nitrogen;Waste;WasteWater;Ammonia
 
 		//TAC-LS
 		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater

--- a/GameData/WildBlueIndustries/MOLE/Parts/Utility/MOH18.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Utility/MOH18.cfg
@@ -96,8 +96,8 @@ PART
 		//Snacks
 		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
 
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+		//Kerbalism, now with more possible resources, partly based on which configuration of Life Support Modules are in place
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen;Water;Nitrogen;Waste;WasteWater;Ammonia
 
 		//TAC-LS
 		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater

--- a/GameData/WildBlueIndustries/MOLE/Parts/Utility/StationHub.cfg
+++ b/GameData/WildBlueIndustries/MOLE/Parts/Utility/StationHub.cfg
@@ -89,8 +89,8 @@ PART
 		//Snacks
 		resourcesToKeep:NEEDS[SnacksUtils] = ElectricCharge;Snacks
 
-		//Kerbalism
-		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen
+		//Kerbalism, now with more possible resources, partly based on which configuration of Life Support Modules are in place
+		resourcesToKeep:NEEDS[Kerbalism] = ElectricCharge;Shielding;Food;Oxygen;Water;Nitrogen;Waste;WasteWater;Ammonia
 
 		//TAC-LS
 		resourcesToKeep:NEEDS[TacLifeSupport] = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater


### PR DESCRIPTION
Descriptions of changes in each file, mostly updating resources. #11 

Further balancing is probably warranted, particularly for the storage template.

The bonus science transmission will require an update of either the Wild Blue plugin to make use of the Kerbalism Antenna Module which replaces the stock ModuleDataTransmitter if the Signal feature is enabled (not unlike using RemoteTech, i.e. custom Antenna module).